### PR TITLE
Fix contact title wrapping

### DIFF
--- a/css/contacto.css
+++ b/css/contacto.css
@@ -35,6 +35,7 @@
   margin-bottom: 20px;
   letter-spacing: -0.02em;
   font-family: "SF Pro Display", "SF Pro Icons", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  white-space: nowrap;
 }
 
 .contact-hero p {
@@ -426,6 +427,7 @@
 @media (max-width: 768px) {
   .contact-hero h1 {
     font-size: 2.5rem;
+    white-space: nowrap;
   }
   
   .contact-hero p {
@@ -462,9 +464,10 @@
   .contact-hero {
     padding: 120px 0 60px 0;
   }
-  
+
   .contact-hero h1 {
     font-size: 2rem;
+    white-space: nowrap;
   }
   
   .contact-form-section {


### PR DESCRIPTION
## Summary
- prevent hero title from wrapping on contact page by adding `white-space: nowrap` across breakpoints

## Testing
- `grep -n "white-space" -n css/contacto.css`

------
https://chatgpt.com/codex/tasks/task_e_68488f1b78288327afdee3b05c9a1323